### PR TITLE
cross_prediction in place of correct_prediction.

### DIFF
--- a/01_Simple_Linear_Model.ipynb
+++ b/01_Simple_Linear_Model.ipynb
@@ -837,7 +837,7 @@
     "    # Use TensorFlow to get a list of boolean values\n",
     "    # whether each test-image has been correctly classified,\n",
     "    # and a list for the predicted class of each image.\n",
-    "    correct, cls_pred = session.run([correct_prediction, y_pred_cls],\n",
+    "    correct, cls_pred = session.run([cross_prediction, y_pred_cls],\n",
     "                                    feed_dict=feed_dict_test)\n",
     "\n",
     "    # Negate the boolean array.\n",


### PR DESCRIPTION
NameError: global name 'correct_prediction' is not defined so it needs cross_prediction in place of correct_prediction.