### PR TITLE
scipy import and file_name fix

### DIFF
--- a/16_Reinforcement_Learning.ipynb
+++ b/16_Reinforcement_Learning.ipynb
@@ -547,7 +547,7 @@
     "\n",
     "```\n",
     "source activate tf-gpu-gym  # Activate your Python environment with TF and Gym.\n",
-    "python reinforcement-learning.py --env Breakout-v0 --training\n",
+    "python reinforcement_learning.py --env Breakout-v0 --training\n",
     "```"
    ]
   },

--- a/reinforcement_learning.py
+++ b/reinforcement_learning.py
@@ -158,7 +158,7 @@
 import numpy as np
 import tensorflow as tf
 import gym
-import scipy.ndimage
+import scipy
 import sys
 import os
 import time


### PR DESCRIPTION
1.) Fixing `import scipy` so the utilization of `scipy.misc.imresize` works correctly in `_pre_process_image()` in the `reinforcement_learning.py` file. 

2.) Fix typo of file name in Reinforcement Learning notebook