### PR TITLE
normalize confusion matrix plot

### DIFF
--- a/01_Simple_Linear_Model.ipynb
+++ b/01_Simple_Linear_Model.ipynb
@@ -46,6 +46,7 @@
    "source": [
     "%matplotlib inline\n",
     "import matplotlib.pyplot as plt\n",
+    "from matplotlib.colors import LogNorm\n",
     "import tensorflow as tf\n",
     "import numpy as np\n",
     "from sklearn.metrics import confusion_matrix"
@@ -767,7 +768,7 @@
     "    print(cm)\n",
     "\n",
     "    # Plot the confusion matrix as an image.\n",
-    "    plt.imshow(cm, interpolation='nearest', cmap=plt.cm.Blues)\n",
+    "    plt.imshow(cm, interpolation='nearest', cmap=plt.cm.Blues, norm=LogNorm())\n",
     "\n",
     "    # Make various adjustments to the plot.\n",
     "    plt.tight_layout()\n",


### PR DESCRIPTION
By not normalizing the data prior to plotting, the differences are difficult to see. The only caveat of this is that the colormap labels obfuscate the true data that is being plotted. There may be some tricks that can be done by manually changing the colormap object, similar example [here](https://scipy-cookbook.readthedocs.io/items/Matplotlib_ColormapTransformations.html).

Before normalization
![](https://i.gyazo.com/11833be65b7e5dd2bc572dccffef48f6.png)


After normalization
![](https://i.gyazo.com/6a0c9bdf07d9cf133ac23851ed29dcac.png)
